### PR TITLE
Add scripting

### DIFF
--- a/aiserver.py
+++ b/aiserver.py
@@ -546,6 +546,7 @@ def build_base_context_transformers():
 
   # Memory
   memory_tokens = tokenizer.encode(vars.memory)[-int(vars.max_length / 2):] # Turn memory into tokens and cut any excess off the start
+  remaining_tokens -= len(memory_tokens)
 
   # History
   history = vars.actions[:] # Copy actions list

--- a/aiserver.py
+++ b/aiserver.py
@@ -63,6 +63,14 @@ class vars:
     hascuda     = False  # Whether torch has detected CUDA on the system
     usegpu      = False  # Whether to launch pipeline with GPU support
     custmodpth  = ""     # Filesystem location of custom model to run
+    scripts = { # Text form of javascript story scripts
+      'shared': "",
+      'inputModifier': "",
+      'contextModifier': "",
+      'outputModifier': "",
+    }
+    script_state = {} # Saved data from clientside scripts.
+    last_context = "" # The last context received from the client. Used when retrying to avoid having the make + request a context again.
 
 #==================================================================#
 # Function to get model selection at startup
@@ -70,7 +78,7 @@ class vars:
 def getModelSelection():
     print("    #   Model                   {0}\n    ==================================="
         .format("VRAM" if vars.hascuda else "    "))
-    
+
     i = 1
     for m in modellist:
         if(vars.hascuda):
@@ -87,19 +95,19 @@ def getModelSelection():
             vars.model = modellist[int(modelsel)-1][1]
         else:
             print("{0}Please enter a valid selection.{1}".format(colors.FAIL, colors.ENDC))
-    
+
     # If custom model was selected, get the filesystem location and store it
     if(vars.model == "NeoCustom" or vars.model == "GPT2Custom"):
         print("{0}Please choose the folder where pytorch_model.bin is located:{1}\n".format(colors.OKCYAN, colors.ENDC))
-        
+
         root = tk.Tk()
         root.attributes("-topmost", True)
         path = filedialog.askdirectory(
-            initialdir=getcwd(), 
-            title="Select Model Folder", 
+            initialdir=getcwd(),
+            title="Select Model Folder",
             )
         root.destroy()
-        
+
         if(path != None and path != ""):
             # Save directory to vars
             vars.custmodpth = path
@@ -181,7 +189,7 @@ if(vars.model != "InferKit"):
     if(not vars.noai):
         print("{0}Initializing transformers, please wait...{1}".format(colors.HEADER, colors.ENDC))
         from transformers import pipeline, GPT2Tokenizer, GPT2LMHeadModel, GPTNeoForCausalLM
-        
+
         # If custom GPT Neo model was chosen
         if(vars.model == "NeoCustom"):
             model     = GPTNeoForCausalLM.from_pretrained(vars.custmodpth)
@@ -208,12 +216,12 @@ if(vars.model != "InferKit"):
                 generator = pipeline('text-generation', model=vars.model, device=0)
             else:
                 generator = pipeline('text-generation', model=vars.model)
-        
+
         print("{0}OK! {1} pipeline created!{2}".format(colors.OKGREEN, vars.model, colors.ENDC))
 else:
     # Import requests library for HTTPS calls
     import requests
-    
+
     # Set generator variables to match InferKit's capabilities
     vars.max_length = 3000
     vars.genamt     = 200
@@ -224,7 +232,7 @@ else:
 def index():
     return render_template('index.html')
 
-#============================ METHODS =============================#    
+#============================ METHODS =============================#
 
 #==================================================================#
 # Event triggered when browser SocketIO is loaded and connects to server
@@ -238,7 +246,8 @@ def do_connect():
         refresh_settings()
     else:
         # Game in session, send current game data and ready state to browser
-        refresh_story()
+        refresh_story({'all': True})
+        send_script_state()
         refresh_settings()
         if(vars.mode == "play"):
             if(not vars.aibusy):
@@ -259,7 +268,7 @@ def get_message(msg):
     # Submit action
     if(msg['cmd'] == 'submit'):
         if(vars.mode == "play"):
-            actionsubmit(msg['data'])
+            actionsubmit(msg['data'], msg['stop'])
         elif(vars.mode == "edit"):
             editsubmit(msg['data'])
         elif(vars.mode == "memory"):
@@ -268,12 +277,16 @@ def get_message(msg):
     elif(msg['cmd'] == 'retry'):
         if(vars.aibusy):
             return
-        set_aibusy(1)
-        # Remove last action if possible and resubmit
+       # Remove last action if possible and resubmit
         if(len(vars.actions) > 0):
             vars.actions.pop()
-            refresh_story()
-            calcsubmit('')
+            refresh_story({'actions': True})
+            # Use last received context (if present)
+            if(vars.last_context != ""):
+              generate(vars.last_context)
+            else:
+              # Otherwise, make the context over again
+              prepare_generation()
     # Back/Undo Action
     elif(msg['cmd'] == 'back'):
         if(vars.aibusy):
@@ -281,7 +294,7 @@ def get_message(msg):
         # Remove last index of actions and refresh game screen
         if(len(vars.actions) > 0):
             vars.actions.pop()
-            refresh_story()
+            refresh_story({'actions': True})
     # EditMode Action
     elif(msg['cmd'] == 'edit'):
         if(vars.mode == "play"):
@@ -323,189 +336,358 @@ def get_message(msg):
     elif(msg['cmd'] == 'anotedepth'):
         vars.andepth = int(msg['data'])
         emit('from_server', {'cmd': 'setlabelanotedepth', 'data': msg['data']})
+    elif(msg['cmd'] == 'generate'):
+        generate(msg['data'])
+    elif(msg['cmd'] == 'newoutput'):
+        add_new_output(msg['data'])
+    elif(msg['cmd'] == 'recordscriptstate'):
+        # Update script state record
+        vars.script_state = msg['data']
 
 #==================================================================#
-#   
+# Adds on a new action, treating it as a fresh output
+#==================================================================#
+def add_new_output(text):
+    vars.actions.append(text)
+    refresh_story({'actions': True})
+    emit('from_server', {'cmd': 'texteffect', 'data': len(vars.actions)})
+
+#==================================================================#
+# Triggers generation of a new AI output using the provided input
+#==================================================================#
+def generate(context=""):
+  if(vars.aibusy):
+    return
+  set_aibusy(1)
+
+  # Format the context appropriately for the given model
+  # For all transformers models
+  if(vars.model != "InferKit"):
+    format_return = format_transformers(context)
+    vars.last_context = tokenizer.decode(format_return) # Store the context in case the player wants to retry this session.
+  # For InferKit web API
+  else:
+    format_return = format_inferkit(context)
+    vars.last_context = format_return # Store the context in case the player wants to retry this session.
+
+  # Submit the formatted context to the appropriate model
+  if(vars.model != "InferKit"): # transformer
+    generated_output = generate_transformers(format_return)
+  else: # InferKit
+    generated_output = generate_inferkit(format_return)
+
+  set_aibusy(0)
+  # Don't add the output to actions yet
+  # Instead, send it to the client to be processed through its outputModifier script
+  emit('from_server', {'cmd': 'modoutput', 'data': generated_output})
+
+#==================================================================#
+# Formats given input for use in transformers models
+#==================================================================#
+def format_transformers(context):
+  # (Is vars.genamt supposed to be tokens or text? Original `calcsubmit` function suggests its supposed to be tokens.)
+  # (for now, treating it as tokens)
+  tokens = tokenizer.encode(context)
+
+  if ((len(tokens) + vars.genamt) > vars.max_length):
+    # Cut off excess tokens so it doesn't go over the limit (removing tokens from the start)
+    # while also allowing space for generated tokens
+    tokens = tokens[len(tokens) - vars.max_length + vars.genamt:]
+
+  return tokens
+
+#==================================================================#
+# Formats given input for use in the InferKit model
+#==================================================================#
+def format_inferkit(context):
+  new_context = context
+
+  if(len(new_context) > vars.max_length):
+    # Cut off excess text so it doesn't go over the limit (cutting away text off the start)
+    new_context = new_context[len(new_context) - vars.max_length:]
+
+  return new_context
+
+#==================================================================#
+# Generates an output using the transformers model
+#==================================================================#
+def generate_transformers(tokens):
+  token_length = len(tokens)
+
+  txt = tokenizer.decode(tokens)
+  min = token_length+1
+  max = token_length+vars.genamt
+
+  print("{0}Min:{1}, Max:{2}, Txt:{3}{4}".format(colors.WARNING, min, max, txt, colors.ENDC))
+
+  # Clear CUDA cache if using GPU
+  if(vars.hascuda and vars.usegpu):
+    torch.cuda.empty_cache()
+
+  # Submit input text to generator
+  generator_output = generator(
+    txt,
+    do_sample=True,
+    min_length=min,
+    max_length=max,
+    repetition_penalty=vars.rep_pen,
+    temperature=vars.temp
+    )[0]["generated_text"]
+  print("{0}{1}{2}".format(colors.OKCYAN, generator_output, colors.ENDC))
+
+  # Clear CUDA cache again if using GPU
+  if(vars.hascuda and vars.usegpu):
+    torch.cuda.empty_cache()
+
+  set_aibusy(0)
+
+  return getnewcontent(generator_output)
+
+#==================================================================#
+# Generates an output using the InferKit API
+#==================================================================#
+def generate_inferkit(txt):
+    # Log request to console
+    print("{0}Len:{1}, Txt:{2}{3}".format(colors.WARNING, len(txt), txt, colors.ENDC))
+
+    # Build request JSON data
+    reqdata = {
+        'forceNoEnd': True,
+        'length': vars.genamt,
+        'prompt': {
+            'isContinuation': False,
+            'text': txt
+        },
+        'startFromBeginning': False,
+        'streamResponse': False,
+        'temperature': vars.temp,
+        'topP': 0.9
+    }
+
+    # Create request
+    req = requests.post(
+        vars.url,
+        json    = reqdata,
+        headers = {
+            'Authorization': 'Bearer '+vars.apikey
+            }
+        )
+
+    # Deal with the response
+    if(req.status_code == 200):
+        genout = req.json()["data"]["text"]
+        print("{0}{1}{2}".format(colors.OKCYAN, genout, colors.ENDC))
+
+        set_aibusy(0)
+
+        return genout
+    else:
+        # Send error message to web client
+        er = req.json()
+        if("error" in er):
+            code = er["error"]["extensions"]["code"]
+        elif("errors" in er):
+            code = er["errors"][0]["extensions"]["code"]
+
+        errmsg = "InferKit API Error: {0} - {1}".format(req.status_code, code)
+        emit('from_server', {'cmd': 'errmsg', 'data': errmsg})
+        set_aibusy(0)
+
+#==================================================================#
+# Sends request to edit base context to client (starting off chain leading to generating an output)
+#==================================================================#
+def prepare_generation():
+  # Create a base context and send it off to the client to edit with its contextModifier script
+  # If the client responds, generation will begin
+  emit('from_server', {'cmd': 'modcontext', 'data': build_base_context()})
+
+#==================================================================#
+# Generates a context that will ultimately be fed to the generator after going through client's contextModifier
+#==================================================================#
+def build_base_context():
+  if(vars.model != "InferKit"): #Transformers model
+    return build_base_context_transformers()
+  else: #InferKit API
+    return build_base_context_inferkit()
+
+#==================================================================#
+# Creates a context for transformers-based models
+#==================================================================#
+def build_base_context_transformers():
+  # Current rules:
+  # - Memory cannot exceed half the max token amount, and the start will be cut off to fit
+  # - Any remaining space will consist of as much history as possible (most recent actions, going back to and including prompt)
+  # - Space is made for vars.genamt if necessary by shortening history
+  # - Author's note will only be included if set
+  # - If there's not enough depth for authors notes, it will be inserted after memory, before history
+  # - Author note depth starts from last history entry, counting back. Depth 1 means author's note will be posted after all actions.
+  # Order:
+  # - Memory
+  # - History
+  # - Authors note (at its appropriate depth)
+  # - History (remaining)
+
+  # (Note: I couldn't work out if transformers max_length works in string length, or token amount.
+  # Based on previous code, I assume it's token amount, which I'll be operating off for here)
+  memory_tokens = []
+  history_tokens = []
+
+  remaining_tokens = vars.max_length - vars.genamt
+
+  author_note_tokens = []
+  author_note_text = "" # Placeholder for Author's Note text
+  author_note_pos = -1 # Records number of entries from the end of history that author's note tokens should be inserted into
+
+  # Build Author's Note if set
+  if(vars.authornote != ""):
+    author_note_text  = "\n[Author's note: "+vars.authornote+"]\n"
+    author_note_tokens = tokenizer.encode(author_note_text)
+    remaining_tokens -= len(author_note_tokens)
+
+  # Memory
+  memory_tokens = tokenizer.encode(vars.memory)[-int(vars.max_length / 2):] # Turn memory into tokens and cut any excess off the start
+
+  # History
+  history = vars.actions[:] # Copy actions list
+  history.insert(0, vars.prompt) # Add the prompt to the start, for ease of use
+
+  depth = 0 # Record depth for inserting authors note
+  for current_history in reversed(history):
+    if(remaining_tokens <= 0):
+      break
+
+    # Author's note
+    depth += 1
+    if(author_note_text != "" and depth == vars.andepth):
+      # Record how far from the end that the author note tokens should be inserted
+      author_note_pos = len(history_tokens)
+
+    current_tokens = tokenizer.encode(current_history)
+    history_tokens = current_tokens[-remaining_tokens:] + history_tokens # Insert up to remaining tokens (cutting off the start if necessary) to start (as we're working backwards)
+
+    remaining_tokens -= len(current_tokens) # (will go below zero, but that should be fine for our purposes)
+
+  # Add author's note before finishing
+  if (author_note_text != ""):
+    if (author_note_pos != -1):
+      # Insert author's note tokens into the right place in history tokens
+      history_tokens[len(history_tokens)-author_note_pos:len(history_tokens)-author_note_pos] = author_note_tokens
+
+      return tokenizer.decode(memory_tokens + history_tokens)
+    else:
+      # Didn't get to appropriate depth!
+      # Add the author's note between memory and history
+      return tokenizer.decode(memory_tokens + author_note_tokens + history_tokens)
+  else:
+    # Return the combined memory + history, decoded back into text
+    return tokenizer.decode(memory_tokens + history_tokens)
+
+#==================================================================#
+# Creates a context for the InferKit API
+#==================================================================#
+def build_base_context_inferkit():
+  # Current rules:
+  # - Memory cannot exceed half the max length, and the start will be cut off to fit
+  # - Any remaining space will consist of as much history as possible (most recent actions, going back to and including prompt)
+  # - History will have the start cut off to fit
+  # - Author's note will only be included if set
+  # - If there's not enough depth for authors notes, it will be inserted after memory, before history
+  # - Author note depth starts from last history entry, counting back. Depth 1 means author's note will be posted after all actions.
+  # Order:
+  # - Memory
+  # - History
+  # - Authors note (at its appropriate depth)
+  # - History (remaining)
+
+  memory_section = ""
+  history_section = ""
+  author_note_text = "" # Placeholder for Author's Note text
+  author_note_pos = -1 # Records number of entries from the end of history that author's note tokens should be inserted into
+
+  remaining_length = vars.max_length
+
+  # Build Author's Note if set
+  if(vars.authornote != ""):
+    author_note_text = "\n[Author's note: "+vars.authornote+"]\n"
+    remaining_length -= len(author_note_text)
+
+  # Memory
+  memory_section = vars.memory[-int(vars.max_length / 2):]
+  remaining_length -= len(memory_section)
+
+  # History
+  history = vars.actions[:] # Copy actions list
+  history.insert(0, vars.prompt) # Add the prompt to the start, for ease of use
+
+  depth = 0 # Record depth for inserting authors note
+  for current_history in reversed(history):
+    if(remaining_length <= 0):
+      break
+
+    # Author's notes
+    depth += 1
+    if(author_note_text != "" and depth == vars.andepth):
+      # Record how far from the end that the author note tokens should be inserted
+      author_note_pos = len(history_section)
+
+    history_section = current_history[-remaining_length:] + history_section # Insert up to remaining length (cutting off the start if necessary) to start (as we're working backwards)
+    remaining_length -= len(current_history) # (will go below zero, but that should be fine for our purposes)
+
+  # Add author's note before finishing
+  if (author_note_text != ""):
+    if (author_note_pos != -1):
+      # Insert author's note into the right place in the history
+      # (Temporarily make it into a list so its easier to insert the text in a specific place)
+      temp_list = list(history_section)
+      temp_list.insert(len(history_section)-author_note_pos, author_note_text)
+
+      history_section = "".join(temp_list)
+
+      return memory_section + history_section
+    else:
+      # Didn't get to appropriate depth!
+      # Add the author's note between memory and history
+      return memory_section + author_note_text + history_section
+  else:
+    # Return the combined memory + history
+    return memory_section + history_section
+#==================================================================#
+#
 #==================================================================#
 def setStartState():
     emit('from_server', {'cmd': 'updatescreen', 'data': '<span>Welcome to <span class="color_cyan">KoboldAI Client</span>! You are running <span class="color_green">'+vars.model+'</span>.<br/>Please load a game or enter a prompt below to begin!</span>'})
+
+    # Send client basic script info, so they can execute scripts from the start
+    vars.scripts = get_default_scripts()
+    vars.script_state = {}
+    send_script_state()
+
+    update_client_data({'all': True}) # Update all their stored data (data from previous stories would otherwise persist until the start prompt is given)
+
     emit('from_server', {'cmd': 'setgamestate', 'data': 'start'})
 
 #==================================================================#
-# 
+#
 #==================================================================#
-def actionsubmit(data):
-    if(vars.aibusy):
-        return
-    set_aibusy(1)
+def actionsubmit(text, should_stop):
+    # Special case if game hasn't started yet:
+    # Ignore should_stop and bypass requesting context. Generate right away using only given text.
     if(not vars.gamestarted):
         vars.gamestarted = True # Start the game
-        vars.prompt = data # Save this first action as the prompt
+        vars.prompt = text # Save this first action as the prompt
+        update_client_data({'prompt': True}) # Tell the client to record the prompt
         emit('from_server', {'cmd': 'updatescreen', 'data': 'Please wait, generating story...'}) # Clear the startup text from game screen
-        calcsubmit(data) # Run the first action through the generator
+        prepare_generation() # Begin generation
     else:
         # Dont append submission if it's a blank/continue action
-        if(data != ""):
-            vars.actions.append(data)
-        calcsubmit(data)
+        if(text != ""):
+            vars.actions.append(text)
+            refresh_story({'actions': True}) # Update the client's view + action record
 
-#==================================================================#
-# Take submitted text and build the text to be given to generator
-#==================================================================#
-def calcsubmit(txt):
-    vars.lastact = txt   # Store most recent action in memory (is this still needed?)
-    anotetxt     = ""    # Placeholder for Author's Note text
-    lnanote      = 0     # Placeholder for Author's Note length
-    forceanote   = False # In case we don't have enough actions to hit A.N. depth
-    anoteadded   = False # In case our budget runs out before we hit A.N. depth
-    actionlen    = len(vars.actions)
-    
-    # Build Author's Note if set
-    if(vars.authornote != ""):
-        anotetxt  = "\n[Author's note: "+vars.authornote+"]\n"
-    
-    # For all transformers models
-    if(vars.model != "InferKit"):
-        anotetkns    = []  # Placeholder for Author's Note tokens
-        
-        # Calculate token budget
-        prompttkns = tokenizer.encode(vars.prompt)
-        lnprompt   = len(prompttkns)
-        
-        memtokens = tokenizer.encode(vars.memory)
-        lnmem     = len(memtokens)
-        
-        if(anotetxt != ""):
-            anotetkns = tokenizer.encode(anotetxt)
-            lnanote   = len(anotetkns)
-        
-        budget = vars.max_length - lnprompt - lnmem - lnanote - vars.genamt
-        
-        if(actionlen == 0):
-            # First/Prompt action
-            subtxt = vars.memory + anotetxt + vars.prompt
-            lnsub  = lnmem + lnprompt + lnanote
-            
-            generate(subtxt, lnsub+1, lnsub+vars.genamt)
-        else:
-            tokens     = []
-            
-            # Check if we have the action depth to hit our A.N. depth
-            if(anotetxt != "" and actionlen < vars.andepth):
-                forceanote = True
-            
-            # Get most recent action tokens up to our budget
-            for n in range(actionlen):
-                
-                if(budget <= 0):
-                    break
-                acttkns = tokenizer.encode(vars.actions[(-1-n)])
-                tknlen = len(acttkns)
-                if(tknlen < budget):
-                    tokens = acttkns + tokens
-                    budget -= tknlen
-                else:
-                    count = budget * -1
-                    tokens = acttkns[count:] + tokens
-                    break
-                
-                # Inject Author's Note if we've reached the desired depth
-                if(n == vars.andepth-1):
-                    if(anotetxt != ""):
-                        tokens = anotetkns + tokens # A.N. len already taken from bdgt
-                        anoteadded = True
-                    
-            # Did we get to add the A.N.? If not, do it here
-            if(anotetxt != ""):
-                if((not anoteadded) or forceanote):
-                    tokens = memtokens + anotetkns + prompttkns + tokens
-                else:
-                    tokens = memtokens + prompttkns + tokens
-            else:
-                # Prepend Memory and Prompt before action tokens
-                tokens = memtokens + prompttkns + tokens
-            
-            # Send completed bundle to generator
-            ln = len(tokens)
-            generate (
-                tokenizer.decode(tokens),
-                ln+1,
-                ln+vars.genamt
-                )
-    # For InferKit web API
-    else:
-        
-        # Check if we have the action depth to hit our A.N. depth
-        if(anotetxt != "" and actionlen < vars.andepth):
-            forceanote = True
-        
-        budget = vars.max_length - len(vars.prompt) - len(anotetxt) - len(vars.memory) - 1
-        subtxt = ""
-        for n in range(actionlen):
-            
-            if(budget <= 0):
-                    break
-            actlen = len(vars.actions[(-1-n)])
-            if(actlen < budget):
-                subtxt = vars.actions[(-1-n)] + subtxt
-                budget -= actlen
-            else:
-                count = budget * -1
-                subtxt = vars.actions[(-1-n)][count:] + subtxt
-                break
-            
-            # Inject Author's Note if we've reached the desired depth
-            if(n == vars.andepth-1):
-                if(anotetxt != ""):
-                    subtxt = anotetxt + subtxt # A.N. len already taken from bdgt
-                    anoteadded = True
-        
-        # Format memory for inclusion (adding newline separator)
-        memsub = ""
-        if(vars.memory != ""):
-            memsub = vars.memory + "\n"
-        
-        # Did we get to add the A.N.? If not, do it here
-        if(anotetxt != ""):
-            if((not anoteadded) or forceanote):
-                subtxt = memsub + anotetxt + vars.prompt + subtxt
-            else:
-                subtxt = memsub + vars.prompt + subtxt
-        else:
-            subtxt = memsub + vars.prompt + subtxt
-        
-        # Send it!
-        ikrequest(subtxt)
-
-#==================================================================#
-# Send text to generator and deal with output
-#==================================================================#
-def generate(txt, min, max):    
-    print("{0}Min:{1}, Max:{2}, Txt:{3}{4}".format(colors.WARNING, min, max, txt, colors.ENDC))
-    
-    # Clear CUDA cache if using GPU
-    if(vars.hascuda and vars.usegpu):
-        torch.cuda.empty_cache()
-    
-    # Submit input text to generator
-    genout = generator(
-        txt, 
-        do_sample=True, 
-        min_length=min, 
-        max_length=max,
-        repetition_penalty=vars.rep_pen,
-        temperature=vars.temp
-        )[0]["generated_text"]
-    print("{0}{1}{2}".format(colors.OKCYAN, genout, colors.ENDC))
-    vars.actions.append(getnewcontent(genout))
-    refresh_story()
-    emit('from_server', {'cmd': 'texteffect', 'data': len(vars.actions)})
-    
-    # Clear CUDA cache again if using GPU
-    if(vars.hascuda and vars.usegpu):
-        torch.cuda.empty_cache()
-    
-    set_aibusy(0)
+        if(not should_stop):
+          # Continue on to requesting context from the client.
+          # If a response is given, it'll eventually move on to generating
+          prepare_generation()
 
 #==================================================================#
 # Replaces returns and newlines with HTML breaks
@@ -517,24 +699,51 @@ def formatforhtml(txt):
 #  Strips submitted text from the text returned by the AI
 #==================================================================#
 def getnewcontent(txt):
-    ln = len(vars.actions)
-    if(ln == 0):
-        delim = vars.prompt
-    else:
-        delim = vars.actions[-1]
-    
-    return (txt.split(delim)[-1])
+    return (txt.split(vars.last_context)[-1])
+
+#==================================================================#
+#  Updates client's data records
+#==================================================================#
+def update_client_data(parameters=None):
+  package = {'cmd': 'updatedata'}
+
+  do_all = False
+  if(parameters is None or parameters.get('all')):
+    do_all = True
+
+  if(do_all or parameters.get('actions')):
+    package['actions'] = vars.actions
+
+  if(do_all or parameters.get('prompt')):
+    package['prompt'] = vars.prompt
+
+  if(do_all or parameters.get('memory')):
+    package['memory'] = vars.memory
+
+  # TODO: Allow for each script to be handled individually
+  if(do_all or parameters.get('scripts')):
+    package['scripts'] = vars.scripts
+
+  # (Technically could utilise the getter and setter events clientside for updating its record)
+  if(do_all or parameters.get('authornote')):
+    package['authornote'] = vars.authornote
+
+  # script_state is handled elsewhere
+  emit('from_server', package)
+
+#==================================================================#
+#  Sends the loaded script state to the client
+#==================================================================#
+def send_script_state():
+  emit('from_server', {'cmd': 'setscriptstate', 'data': vars.script_state})
 
 #==================================================================#
 # Sends the current story content to the Game Screen
 #==================================================================#
-def refresh_story():
-    txt = '<chunk n="0" id="n0">'+vars.prompt+'</chunk>'
-    i = 1
-    for item in vars.actions:
-        txt = txt + '<chunk n="'+str(i)+'" id="n'+str(i)+'">'+item+'</chunk>'
-        i += 1
-    emit('from_server', {'cmd': 'updatescreen', 'data': formatforhtml(txt)})
+def refresh_story(data_parameters=None):
+    update_client_data(data_parameters)
+
+    emit('from_server', {'cmd': 'updatescreen'}) # Client handles generating the html
 
 #==================================================================#
 # Sends the current generator settings to the Game Menu
@@ -558,34 +767,35 @@ def set_aibusy(state):
         emit('from_server', {'cmd': 'setgamestate', 'data': 'ready'})
 
 #==================================================================#
-# 
+#
 #==================================================================#
 def editrequest(n):
     if(n == 0):
         txt = vars.prompt
     else:
         txt = vars.actions[n-1]
-    
+
     vars.editln = n
     emit('from_server', {'cmd': 'setinputtext', 'data': txt})
     emit('from_server', {'cmd': 'enablesubmit', 'data': ''})
 
 #==================================================================#
-# 
+#
 #==================================================================#
 def editsubmit(data):
     if(vars.editln == 0):
         vars.prompt = data
+        update_client_data({'prompt': True})
     else:
         vars.actions[vars.editln-1] = data
-    
+
     vars.mode = "play"
-    refresh_story()
+    refresh_story({'actions': True})
     emit('from_server', {'cmd': 'texteffect', 'data': vars.editln})
     emit('from_server', {'cmd': 'editmode', 'data': 'false'})
 
 #==================================================================#
-#  
+#
 #==================================================================#
 def deleterequest():
     # Don't delete prompt
@@ -618,9 +828,11 @@ def memsubmit(data):
     # Maybe check for length at some point
     # For now just send it to storage
     vars.memory = data
+    update_client_data({'memory': True})
+
     vars.mode = "play"
     emit('from_server', {'cmd': 'memmode', 'data': 'false'})
-    
+
     # Ask for contents of Author's Note field
     emit('from_server', {'cmd': 'getanote', 'data': ''})
 
@@ -631,57 +843,7 @@ def anotesubmit(data):
     # Maybe check for length at some point
     # For now just send it to storage
     vars.authornote = data
-
-#==================================================================#
-#  Assembles game data into a request to InferKit API
-#==================================================================#
-def ikrequest(txt):
-    # Log request to console
-    print("{0}Len:{1}, Txt:{2}{3}".format(colors.WARNING, len(txt), txt, colors.ENDC))
-    
-    # Build request JSON data
-    reqdata = {
-        'forceNoEnd': True,
-        'length': vars.genamt,
-        'prompt': {
-            'isContinuation': False,
-            'text': txt
-        },
-        'startFromBeginning': False,
-        'streamResponse': False,
-        'temperature': vars.temp,
-        'topP': vars.top_p
-    }
-    
-    # Create request
-    req = requests.post(
-        vars.url, 
-        json    = reqdata,
-        headers = {
-            'Authorization': 'Bearer '+vars.apikey
-            }
-        )
-    
-    # Deal with the response
-    if(req.status_code == 200):
-        genout = req.json()["data"]["text"]
-        print("{0}{1}{2}".format(colors.OKCYAN, genout, colors.ENDC))
-        vars.actions.append(genout)
-        refresh_story()
-        emit('from_server', {'cmd': 'texteffect', 'data': len(vars.actions)})
-        
-        set_aibusy(0)
-    else:
-        # Send error message to web client
-        er = req.json()
-        if("error" in er):
-            code = er["error"]["extensions"]["code"]
-        elif("errors" in er):
-            code = er["errors"][0]["extensions"]["code"]
-            
-        errmsg = "InferKit API Error: {0} - {1}".format(req.status_code, code)
-        emit('from_server', {'cmd': 'errmsg', 'data': errmsg})
-        set_aibusy(0)
+    update_client_data({'authornote': True})
 
 #==================================================================#
 #  Forces UI to Play mode
@@ -696,16 +858,16 @@ def exitModes():
 #==================================================================#
 #  Save the story to a file
 #==================================================================#
-def saveRequest():    
+def saveRequest():
     root = tk.Tk()
     root.attributes("-topmost", True)
     path = filedialog.asksaveasfile(
-        initialdir=vars.savedir, 
-        title="Save Story As", 
+        initialdir=vars.savedir,
+        title="Save Story As",
         filetypes = [("Json", "*.json")]
         )
     root.destroy()
-    
+
     if(path != None and path != ''):
         # Leave Edit/Memory mode before continuing
         exitModes()
@@ -722,7 +884,9 @@ def saveRequest():
         js["memory"]      = vars.memory
         js["authorsnote"] = vars.authornote
         js["actions"]     = vars.actions
-        #js["savedir"]     = path.name  # For privacy, don't include savedir in save file      
+        js["scripts"] = vars.scripts
+        js["script_state"] = vars.script_state
+        #js["savedir"]     = path.name  # For privacy, don't include savedir in save file
         # Write it
         file = open(path.name, "w")
         try:
@@ -733,16 +897,16 @@ def saveRequest():
 #==================================================================#
 #  Load a stored story from a file
 #==================================================================#
-def loadRequest():    
+def loadRequest():
     root = tk.Tk()
     root.attributes("-topmost", True)
     path = filedialog.askopenfilename(
-        initialdir=vars.savedir, 
-        title="Select Story File", 
+        initialdir=vars.savedir,
+        title="Select Story File",
         filetypes = [("Json", "*.json")]
         )
     root.destroy()
-    
+
     if(path != None and path != ''):
         # Leave Edit/Memory mode before continuing
         exitModes()
@@ -759,26 +923,64 @@ def loadRequest():
         vars.memory      = js["memory"]
         vars.actions     = js["actions"]
         #vars.savedir     = js["savedir"] # For privacy, don't include savedir in save file
-        
+
         # Try not to break older save files
         if("authorsnote" in js):
             vars.authornote = js["authorsnote"]
-        
+
+        if("scripts" in js):
+            vars.scripts = js["scripts"]
+        else:
+            vars.scripts = get_default_scripts()
+
+        if("script_state" in js):
+            vars.script_state = js["script_state"]
+        else:
+            vars.script_state = {}
+
+
         file.close()
         # Refresh game screen
-        refresh_story()
+        refresh_story({'all': True})
+        send_script_state()
         emit('from_server', {'cmd': 'setgamestate', 'data': 'ready'})
+
+#==================================================================#
+#  Provides the default starting scripts, loaded from files
+#==================================================================#
+
+def get_default_scripts():
+  path = getcwd()+"\\templates\\"
+  scripts = {}
+
+  file = open(path+"shared.js", "r")
+  scripts['shared'] = file.read()
+  file.close()
+
+  file = open(path+"inputModifier.js", "r")
+  scripts['inputModifier'] = file.read()
+  file.close()
+
+  file = open(path+"contextModifier.js", "r")
+  scripts['contextModifier'] = file.read()
+  file.close()
+
+  file = open(path+"outputModifier.js", "r")
+  scripts['outputModifier'] = file.read()
+  file.close()
+
+  return scripts
 
 #==================================================================#
 #  Starts a new story
 #==================================================================#
-def newGameRequest(): 
+def newGameRequest():
     # Ask for confirmation
     root = tk.Tk()
     root.attributes("-topmost", True)
     confirm = messagebox.askquestion("Confirm New Game", "Really start new Story?")
     root.destroy()
-    
+
     if(confirm == "yes"):
         # Leave Edit/Memory mode before continuing
         exitModes()
@@ -788,6 +990,9 @@ def newGameRequest():
         vars.memory      = ""
         vars.actions     = []
         vars.savedir     = getcwd()+"\stories\\newstory.json"
+        vars.scripts = get_default_scripts()
+        vars.script_state = {}
+        vars.last_context = ""
         # Refresh game screen
         setStartState()
 

--- a/templates/contextModifier.js
+++ b/templates/contextModifier.js
@@ -1,0 +1,3 @@
+const modifier = (text) => {
+	return {text}
+}

--- a/templates/inputModifier.js
+++ b/templates/inputModifier.js
@@ -1,0 +1,3 @@
+const modifier = (text) => {
+	return {text}
+}

--- a/templates/outputModifier.js
+++ b/templates/outputModifier.js
@@ -1,0 +1,3 @@
+const modifier = (text) => {
+	return {text}
+}


### PR DESCRIPTION
_(This hasn't been extensively tested and may contain bugs, however I'm pushing this now because I'm falling behind on changes to the main repo, and don't know how to properly merge changes (the tutorials on sorting merge conflicts on github are pretty rubbish :P))_
### Summary
Adds the ability for users to use scripts to modify their inputs, the context provided to the AI, and the AI's outputs in a similar format to the scripts as they appear in AI Dungeon.
**Notable other changes:**

- The client now holds copies of some of the data that's relevant for scripting, such as actions, the prompt, memory, etc.
- Generation was reformatted somewhat, though I attempted to keep everything as close to as it was previously based on my understanding of it. There's additional stages wherein the client has a chance to modify the text that gets fed to the AI, as well as prevent generation from happening (so they can submit actions without triggering generation, for example).

### Basic Documentation
_(this is copied from the [reddit post](https://www.reddit.com/r/KoboldAI/comments/n6y14d/looking_for_people_to_test_scripting/))_
**The Scripts**
There are 4 scripts in total, which anyone with experience with AIDungeon will be familiar with:

* `shared` \- This contains any variables or functions you want to be available across all the other scripts.
* `inputModifier` \- The player's input is fed through this before being sent. Whatever is returned as `text` in the object returned from the `modifier` function will be used as the player's input. If `stop` is included and set to `true`, the input will be sent to the server, but the AI won't generate a response to it.
* `contextModifier` \- The block of text that's going to be sent to the AI is fed through this before being used. Similarly to `inputModifier`, the `text` value that's sent back is what's used, and `stop` can be used to stop the AI from generating anything!
* `outputModifier` \- The AI's generated output is fed through this before its actually saved. As before, return an altered `text` value if you want to change anything. `stop` won't do anything here - the AI has already generated its output!

**Special Variables**
In addition to whatever's been defined in `shared`, scripts have access to the following variables:

* `text` \- The text fed into the modifier, which changes based on where it's being used.
   * In the input modifier, this'll be the player's input.
   * In context modifier, this'll be the base context that was generated by the server (containing the memory, author's note, and recent actions all formatted ready to be input to the AI generator).
   * In output modifier, this'll be the text output by the AI.
* `actions` \- This is an array recording *all* the actions (player inputs, and AI outputs) that have happened so far in order (I should probably trim them down after a certain length...). This is just a copy of the one that's actually used, so you can't just insert new actions in (I think :P)!
* `memory` \- This is whatever has been entered into memory.
* `state` \- The contents of this object persists between each run of the scripts, and is saved in the save file. Use this to store any information that you want to stay around.
* `authorsNote` \- This is whatever has been entered as the author's note.

### Missing

- UI - There's no interface for editing any of the modifier scripts at the moment. Instead, you must either: save your story and edit the scripts as they appear in the story's `.json` save (recommended), or editing the initial script templates in `templates` before starting a story (not recommended, as this'll effect all stories going forward unless you revert the changes, and you only get that initial chance to set things up). I'm personally not experienced enough to add in the UI myself.
- Sandboxing - I'd originally attempted to make it so the modifier scripts are run in a sandboxed environment so that they can't mess with any of the client stuff that they shouldn't have access to (not that I think it's that harmful if they managed to at the moment), but it turns out trying to do that with zero web development experience is hard :P.
- Synchronisation - Currently, whenever `actions` is altered, the server has to re-send the entire array to the client. Ideally, they'd instead keep each alteration synchronised as they happen (e.g. "remove the last action", "change action number # to read ____") so the only time the full actions list has to be sent is when a story is loaded.
