### PR TITLE
Import fixes

### DIFF
--- a/aiserver.py
+++ b/aiserver.py
@@ -1216,6 +1216,9 @@ def importRequest():
         file = open(importpath, "rb")
         vars.importjs = json.load(file)
         
+        if type(vars.importjs) is dict and "stories" in vars.importjs:
+            vars.importjs = vars.importjs["stories"]
+        
         # Clear Popup Contents
         emit('from_server', {'cmd': 'clearpopup', 'data': ''})
         
@@ -1269,7 +1272,7 @@ def importgame():
         else:
             vars.prompt = ""
         vars.memory      = ref["memory"]
-        vars.authornote  = ref["authorsNote"]
+        vars.authornote  = ref["authorsNote"] if type(ref["authorsNote"]) is str else ""
         vars.actions     = []
         vars.worldinfo   = []
         


### PR DESCRIPTION
I found two issues that can cause the import to fail. This pull request fixes them.

1. Some older versions of the downloader script put the export in one big file. This checks for that so the import still succeeds.
2. If you never used Author's Note (because you didn't have a subscription), it will be `None`. This caused a `TypeError` when you try to continue the story.