### PR TITLE
Makes KoboldAI webserver configurable settings for connecting to it from another device

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,7 @@
 # Ignore client settings file
 client.settings
+# And the server settings
+server.settings
 
 # Ignore stories file except for test_story
 stories/*

--- a/aiserver.py
+++ b/aiserver.py
@@ -123,8 +123,8 @@ def saveServerSettings():
     # Build json to write
     js = {}
     js["open"] = vars.openserver
-    js["port"] = "port": vars.serverport
-    js["host"] = "host": vars.serverhost
+    js["port"] = vars.serverport
+    js["host"] = vars.serverhost
 
     # Write it
     file = open("server.settings",'w')
@@ -179,7 +179,7 @@ def getSettingsMenu():
             toggle_string = vars.openserver and "Enabled! Please note that your traffic is unencrypted, so please only use this for devices on your local network." or "Disabled."
             print_color = not vars.openserver and colors.GREEN or colors.RED
             print("{0}Server {1}{2}".format(print_color, toggle_string, colors.END))
-            saveServerSettings(OPTION_SERVER_OPEN, vars.openserver)
+            saveServerSettings()
         if(optionint == OPTION_SERVER_PORT):
             newportvalue = "error" #we want this to fail checks, just in case
             validport = False
@@ -196,7 +196,7 @@ def getSettingsMenu():
                 validport = True
                 vars.serverport = newportvalue
                 print("{0}Server port set to {1}{2}".format(print_color, newportvalue, colors.END))
-                saveServerSettings(OPTION_SERVER_PORT, vars.serverport)
+                saveServerSettings()
         if(optionint == OPTION_SERVER_HOST):
             newhostvalue = -1 #we want this to fail checks, just in case
             validhost = False
@@ -212,7 +212,7 @@ def getSettingsMenu():
                 validhost = True
                 vars.serverhost = newhostvalue
                 print("{0}Server host set to {1}{2}".format(print_color, newhostvalue, colors.END))
-                saveServerSettings(OPTION_SERVER_HOST, vars.serverhost)
+                saveServerSettings()
         elif(optionint == OPTION_EXIT_SETTINGS):
             return
 

--- a/gensettings.py
+++ b/gensettings.py
@@ -108,3 +108,10 @@ formatcontrols = [{
     "id": "frmtadsnsp",
     "tooltip": "If the last action ended with punctuation, add a space to the beginning of the next action."
     }]
+server = [
+    {
+	"open": False,
+	"port": 5000,
+    "host": '0.0.0.0'
+	}
+]


### PR DESCRIPTION
## Forewarning

I am pretty terrible at python, sorry in advance for doing some bad practices!

## About The Pull Request

KoboldAI now has a "main menu" where you can choose to go ahead to the model selection and server starting, but also over to server settings. Here you can enable and configure a server to host the webserver on instead of 0.0.0.0:5000

This is so you can, say, let your computer run KoboldAI while you use your phone, or whatever other device you want to.

This also means that you can technically do multiplayer with this, but it's more of a consequence of freedom rather than anything else. I haven't hooked up updates to all other clients when one sends an input, so it's a pretty bad multiplayer at the moment. Something about unencrypted data, too. Either way, technically those problems could be solved in the future and we could have true multiplayer which is neat, so I don't think it's an issue right now.

todo:
- [ ] clean up code
- [ ] fix colors not formatting correctly

![image](https://user-images.githubusercontent.com/40974010/119739734-86dc5f00-be37-11eb-8ce4-cbe5b34e1017.png)
