### PR TITLE
Performance increase for `refresh_story` on large stories

### DIFF
--- a/aiserver.py
+++ b/aiserver.py
@@ -1090,12 +1090,10 @@ def applyoutputformatting(txt):
 # Sends the current story content to the Game Screen
 #==================================================================#
 def refresh_story():
-    txt = '<chunk n="0" id="n0">'+vars.prompt+'</chunk>'
-    i = 1
-    for item in vars.actions:
-        txt = txt + '<chunk n="'+str(i)+'" id="n'+str(i)+'">'+item+'</chunk>'
-        i += 1
-    emit('from_server', {'cmd': 'updatescreen', 'data': formatforhtml(txt)})
+    text_parts = ['<chunk n="0" id="n0">', vars.prompt, '</chunk>']
+    for idx, item in enumerate(vars.actions, start=1):
+        text_parts.extend(('<chunk n="', str(idx), '" id="n', str(idx), '">', item, '</chunk>'))
+    emit('from_server', {'cmd': 'updatescreen', 'data': formatforhtml(''.join(text_parts))})
 
 #==================================================================#
 # Sends the current generator settings to the Game Menu


### PR DESCRIPTION
Huge performance increase when generating the HTML by putting all the text chunks in a list before assembling. Speeds up generation by orders of magnitude on large stories. (In my test case, a 2000+ action story went from taking 500ms to generating so fast the monotonic clock didn't have enough resolution to measure it)

The original problem has caused by the fact that when adding strings using `+` and `+=`, memory is allocated to fit both strings being concatenated and then the two are copied in this new area in memory. This meant that for every action added *all the HTML generated to up this point has to be copied* in a new spot in memory. *Every. Time.*

As lists are more flexible mutable containers, there's a lot less memory allocation, and the components can easily and efficiently be added together in one shot with `str.join`.