### PR TITLE
Escape user prompt

### DIFF
--- a/aiserver.py
+++ b/aiserver.py
@@ -1091,7 +1091,7 @@ def applyoutputformatting(txt):
 # Sends the current story content to the Game Screen
 #==================================================================#
 def refresh_story():
-    text_parts = ['<chunk n="0" id="n0">', vars.prompt, '</chunk>']
+    text_parts = ['<chunk n="0" id="n0">', html.escape(vars.prompt), '</chunk>']
     for idx, item in enumerate(vars.actions, start=1):
         text_parts.extend(('<chunk n="', str(idx), '" id="n', str(idx), '">', html.escape(item), '</chunk>'))
     emit('from_server', {'cmd': 'updatescreen', 'data': formatforhtml(''.join(text_parts))})


### PR DESCRIPTION
As 1e95f7e1a5efa906d79430ada57f387976c1a797 doesn't escape the user prompt, this will be changed with this, it will also be escaped.
closes #22 
