### PR TITLE
Migrated install_requirements.bat to conda-forge

### DIFF
--- a/install_requirements.bat
+++ b/install_requirements.bat
@@ -23,7 +23,7 @@ IF ERRORLEVEL 1 (
 miniconda3.exe /S /InstallationType=JustMe /RegisterPython=0 /AddTopath=0 /NoScripts=1 /NoRegistry=1 /D=%~dp0\miniconda3
 del miniconda3.exe
 call miniconda3\condabin\activate
-call conda install --all --no-shortcuts -y git pytorch tensorflow-gpu colorama Flask-SocketIO cudatoolkit=11 -c pytorch
+call conda install --all --no-shortcuts -y git pytorch tensorflow-gpu colorama Flask-SocketIO -c pytorch -c conda-forge
 IF %M%==1 pip install git+https://github.com/finetuneanon/transformers@gpt-neo-localattention3
 IF %M%==2 call conda install --no-shortcuts -y transformers -c huggingface
 call conda clean -a -y


### PR DESCRIPTION
No more manually forcing CUDA to be 11, instead we use conda-forge.
This will pull down a lot more recent versions of pretty much everything, and fixes errors in the GPT-J models that cropped up on the older versions of the dependencies.