### PR TITLE
Fix enter key behaviour in the editor when not using Firefox

### DIFF
--- a/static/application.js
+++ b/static/application.js
@@ -758,7 +758,7 @@ function chunkOnTextInput(event) {
 		// mobile devices, but the other method is also here as
 		// a fallback
 		if(document.queryCommandSupported && document.execCommand && document.queryCommandSupported('insertHTML')) {
-			document.execCommand('insertHTML', false, event.originalEvent.data.slice(0, -1) + '<br id="_EDITOR_LINEBREAK_"/><span id="_EDITOR_SENTINEL_">|</span>');
+			document.execCommand('insertHTML', false, event.originalEvent.data.slice(0, -1).replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;').replace(/"/g, '&quot;').replace(/'/g, '&#039;').replace(/\n/g, '<br/>') + '<br id="_EDITOR_LINEBREAK_"/><span id="_EDITOR_SENTINEL_">|</span>');
 			var t = $('#_EDITOR_SENTINEL_').contents().filter(function() { return this.nodeType === 3; })[0];
 		} else {
 			var t = document.createTextNode('|');
@@ -1043,7 +1043,7 @@ function chunkOnPaste(event) {
 	// paste as plaintext
 	if(event.originalEvent.clipboardData && document.queryCommandSupported && document.execCommand && document.queryCommandSupported('insertText')) {
 		event.preventDefault();
-        document.execCommand('insertText', false, event.originalEvent.clipboardData.getData('text/plain'));
+        document.execCommand('insertHTML', false, event.originalEvent.clipboardData.getData('text/plain').replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;').replace(/"/g, '&quot;').replace(/'/g, '&#039;').replace(/\n/g, '<br/>'));
     }
 }
 

--- a/static/application.js
+++ b/static/application.js
@@ -1044,7 +1044,17 @@ function chunkOnPaste(event) {
 	if(event.originalEvent.clipboardData && document.queryCommandSupported && document.execCommand && document.queryCommandSupported('insertText')) {
 		event.preventDefault();
         document.execCommand('insertHTML', false, event.originalEvent.clipboardData.getData('text/plain').replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;').replace(/"/g, '&quot;').replace(/'/g, '&#039;').replace(/\n/g, '<br/>'));
-    }
+    } else if (event.originalEvent.clipboardData) {
+		event.preventDefault();
+		var s = getSelection();  // WARNING: Do not use rangy.getSelection() instead of getSelection()
+		var r = s.getRangeAt(0);
+		r.deleteContents();
+		var nodes = Array.from($('<span>' + event.originalEvent.clipboardData.getData('text/plain').replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;').replace(/"/g, '&quot;').replace(/'/g, '&#039;').replace(/\n/g, '<br/>') + '</span>')[0].childNodes);
+		for(var i = 0; i < nodes.length; i++) {
+			r.insertNode(nodes[i]);
+			r.collapse(false);
+		}
+	}
 }
 
 // This gets run every time the caret moves in the editor

--- a/static/application.js
+++ b/static/application.js
@@ -1041,7 +1041,7 @@ function chunkOnPaste(event) {
 	}
 	// If possible, intercept paste events into the editor in order to always
 	// paste as plaintext
-	if(event.originalEvent.clipboardData && document.queryCommandSupported && document.execCommand && document.queryCommandSupported('insertText')) {
+	if(event.originalEvent.clipboardData && document.queryCommandSupported && document.execCommand && document.queryCommandSupported('insertHTML')) {
 		event.preventDefault();
         document.execCommand('insertHTML', false, event.originalEvent.clipboardData.getData('text/plain').replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;').replace(/"/g, '&quot;').replace(/'/g, '&#039;').replace(/(?=\r|\n)\r?\n?/g, '<br/>'));
     } else if (event.originalEvent.clipboardData) {

--- a/static/application.js
+++ b/static/application.js
@@ -758,7 +758,7 @@ function chunkOnTextInput(event) {
 		// mobile devices, but the other method is also here as
 		// a fallback
 		if(document.queryCommandSupported && document.execCommand && document.queryCommandSupported('insertHTML')) {
-			document.execCommand('insertHTML', false, event.originalEvent.data.slice(0, -1).replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;').replace(/"/g, '&quot;').replace(/'/g, '&#039;').replace(/\n/g, '<br/>') + '<br id="_EDITOR_LINEBREAK_"/><span id="_EDITOR_SENTINEL_">|</span>');
+			document.execCommand('insertHTML', false, event.originalEvent.data.slice(0, -1).replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;').replace(/"/g, '&quot;').replace(/'/g, '&#039;').replace(/(?=\r|\n)\r?\n?/g, '<br/>') + '<br id="_EDITOR_LINEBREAK_"/><span id="_EDITOR_SENTINEL_">|</span>');
 			var t = $('#_EDITOR_SENTINEL_').contents().filter(function() { return this.nodeType === 3; })[0];
 		} else {
 			var t = document.createTextNode('|');
@@ -1043,13 +1043,13 @@ function chunkOnPaste(event) {
 	// paste as plaintext
 	if(event.originalEvent.clipboardData && document.queryCommandSupported && document.execCommand && document.queryCommandSupported('insertText')) {
 		event.preventDefault();
-        document.execCommand('insertHTML', false, event.originalEvent.clipboardData.getData('text/plain').replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;').replace(/"/g, '&quot;').replace(/'/g, '&#039;').replace(/\n/g, '<br/>'));
+        document.execCommand('insertHTML', false, event.originalEvent.clipboardData.getData('text/plain').replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;').replace(/"/g, '&quot;').replace(/'/g, '&#039;').replace(/(?=\r|\n)\r?\n?/g, '<br/>'));
     } else if (event.originalEvent.clipboardData) {
 		event.preventDefault();
 		var s = getSelection();  // WARNING: Do not use rangy.getSelection() instead of getSelection()
 		var r = s.getRangeAt(0);
 		r.deleteContents();
-		var nodes = Array.from($('<span>' + event.originalEvent.clipboardData.getData('text/plain').replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;').replace(/"/g, '&quot;').replace(/'/g, '&#039;').replace(/\n/g, '<br/>') + '</span>')[0].childNodes);
+		var nodes = Array.from($('<span>' + event.originalEvent.clipboardData.getData('text/plain').replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;').replace(/"/g, '&quot;').replace(/'/g, '&#039;').replace(/(?=\r|\n)\r?\n?/g, '<br/>') + '</span>')[0].childNodes);
 		for(var i = 0; i < nodes.length; i++) {
 			r.insertNode(nodes[i]);
 			r.collapse(false);

--- a/static/application.js
+++ b/static/application.js
@@ -496,6 +496,14 @@ function returnWiList(ar) {
 	socket.send({'cmd': 'sendwilist', 'data': list});
 }
 
+function formatChunkInnerText(chunk) {
+	var text = chunk.innerText.replace(/\u00a0/g, " ");
+	if((chunk.nextSibling === null || chunk.nextSibling.nodeType !== 1 || chunk.nextSibling.tagName !== "CHUNK") && text.slice(-1) === '\n') {
+		return text.slice(0, -1);
+	}
+	return text;
+}
+
 function dosubmit() {
 	var txt = input_text.val().replace(/\u00a0/g, " ");
 	if(!memorymode && !gamestarted && ((!adventure || !action_mode) && txt.trim().length == 0)) {
@@ -750,11 +758,13 @@ function chunkOnTextInput(event) {
 		// mobile devices, but the other method is also here as
 		// a fallback
 		if(document.queryCommandSupported && document.execCommand && document.queryCommandSupported('insertHTML')) {
-			document.execCommand('insertHTML', false, event.originalEvent.data.slice(0, -1) + '<br/><span id="_EDITOR_SENTINEL_">|</span>');
+			document.execCommand('insertHTML', false, event.originalEvent.data.slice(0, -1) + '<br id="_EDITOR_LINEBREAK_"/><span id="_EDITOR_SENTINEL_">|</span>');
 			var t = $('#_EDITOR_SENTINEL_').contents().filter(function() { return this.nodeType === 3; })[0];
 		} else {
 			var t = document.createTextNode('|');
-			r.insertNode(document.createElement('br'));
+			var b = document.createElement('br');
+			b.id = "_EDITOR_LINEBREAK_";
+			r.insertNode(b);
 			r.collapse(false);
 			r.insertNode(t);
 		}
@@ -770,6 +780,25 @@ function chunkOnTextInput(event) {
 			// arrow key in some browsers so we prefer the
 			// document.execCommand method
 			r.deleteContents();
+		}
+
+		// In Chrome the added <br/> will go outside of the chunks if we press
+		// enter at the end of the story in the editor, so this is here
+		// to put the <br/> back in the right place
+		var br = $("#_EDITOR_LINEBREAK_")[0];
+		if(br.parentNode === game_text[0]) {
+			if(br.previousSibling.nodeType !== 1) {
+				br.previousSibling.previousSibling.appendChild(br.previousSibling);
+			}
+			br.previousSibling.appendChild(br);
+			r.selectNodeContents(br.parentNode);
+			s.removeAllRanges();
+			s.addRange(r);
+			r.collapse(false);
+		}
+		br.id = "";
+		if(game_text[0].lastChild.tagName === "BR") {
+			br.parentNode.appendChild(game_text[0].lastChild);
 		}
 		return;
 	}
@@ -815,6 +844,10 @@ function downloadStory(format) {
 	var actionlist_compiled = [];
 	for(var i = 0; i < actionlist.length; i++) {
 		actionlist_compiled.push(actionlist[i].innerText.replace(/\u00a0/g, " "));
+	}
+	var last = actionlist_compiled[actionlist_compiled.length-1];
+	if(last.slice(-1) === '\n') {
+		actionlist_compiled[actionlist_compiled.length-1] = last.slice(0, -1);
 	}
 
 	if(format == "plaintext") {
@@ -890,10 +923,10 @@ function applyChunkDeltas(nodes) {
 		var selected_chunks = buildChunkSetFromNodeArray(getSelectedNodes());
 		for(var i = 0; i < chunks.length; i++) {
 			var chunk = document.getElementById("n" + chunks[i]);
-			if(chunk && chunk.innerText.length != 0 && chunks[i] != '0') {
+			if(chunk && formatChunkInnerText(chunk).length != 0 && chunks[i] != '0') {
 				if(!selected_chunks.has(chunks[i])) {
 					modified_chunks.delete(chunks[i]);
-					socket.send({'cmd': 'inlineedit', 'chunk': chunks[i], 'data': chunk.innerText.replace(/\u00a0/g, " ")});
+					socket.send({'cmd': 'inlineedit', 'chunk': chunks[i], 'data': formatChunkInnerText(chunk)});
 				}
 				empty_chunks.delete(chunks[i]);
 			} else {
@@ -914,7 +947,7 @@ function syncAllModifiedChunks(including_selected_chunks=false) {
 		if(including_selected_chunks || !selected_chunks.has(chunks[i])) {
 			modified_chunks.delete(chunks[i]);
 			var chunk = document.getElementById("n" + chunks[i]);
-			var data = chunk ? document.getElementById("n" + chunks[i]).innerText.replace(/\u00a0/g, " ") : "";
+			var data = chunk ? formatChunkInnerText(document.getElementById("n" + chunks[i])) : "";
 			if(data.length == 0) {
 				empty_chunks.add(chunks[i]);
 			} else {
@@ -927,7 +960,7 @@ function syncAllModifiedChunks(including_selected_chunks=false) {
 
 function restorePrompt() {
 	if(game_text[0].firstChild && game_text[0].firstChild.nodeType === 3) {
-		saved_prompt = game_text[0].firstChild.textContent.replace(/\u00a0/g, " ");
+		saved_prompt = formatChunkInnerText(game_text[0].firstChild);
 		unbindGametext();
 		game_text[0].innerText = "";
 		bindGametext();
@@ -961,9 +994,9 @@ function deleteEmptyChunks() {
 	}
 	if(modified_chunks.has('0')) {
 		modified_chunks.delete(chunks[i]);
-		socket.send({'cmd': 'inlineedit', 'chunk': chunks[i], 'data':  document.getElementById("n0").innerText.replace(/\u00a0/g, " ")});
+		socket.send({'cmd': 'inlineedit', 'chunk': chunks[i], 'data': formatChunkInnerText(document.getElementById("n0"))});
 	}
-	saved_prompt = $("#n0")[0].innerText.replace(/\u00a0/g, " ");
+	saved_prompt = formatChunkInnerText($("#n0")[0]);
 }
 
 function highlightEditingChunks() {
@@ -1203,9 +1236,12 @@ $(document).ready(function(){
 			modified_chunks = new Set();
 			empty_chunks = new Set();
 			game_text.html(msg.data);
+			if(game_text[0].lastChild !== null && game_text[0].lastChild.tagName === "CHUNK") {
+				game_text[0].lastChild.appendChild(document.createElement("br"));
+			}
 			bindGametext();
 			if(gamestarted) {
-				saved_prompt = $("#n0")[0].innerText.replace(/\u00a0/g, " ");
+				saved_prompt = formatChunkInnerText($("#n0")[0]);
 			}
 			// Scroll to bottom of text
 			if(newly_loaded) {
@@ -1217,26 +1253,43 @@ $(document).ready(function(){
 			scrollToBottom();
 		} else if(msg.cmd == "updatechunk") {
 			hideMessage();
-			const {index, html} = msg.data;
-			const existingChunk = game_text.children(`#n${index}`)
-			const newChunk = $(html);
+			var index = msg.data.index;
+			var html = msg.data.html;
+			var existingChunk = game_text.children('#n' + index);
+			var newChunk = $(html);
 			unbindGametext();
 			if (existingChunk.length > 0) {
 				// Update existing chunk
+				if(existingChunk[0].nextSibling === null || existingChunk[0].nextSibling.nodeType !== 1 || existingChunk[0].nextSibling.tagName !== "CHUNK") {
+					newChunk[0].appendChild(document.createElement("br"));
+				}
 				existingChunk.before(newChunk);
 				existingChunk.remove();
 			} else if (!empty_chunks.has(index.toString())) {
 				// Append at the end
+				unbindGametext();
+				var lc = game_text[0].lastChild;
+				if(lc.tagName === "CHUNK" && lc.lastChild !== null && lc.lastChild.tagName === "BR") {
+					lc.removeChild(lc.lastChild);
+				}
+				newChunk[0].appendChild(document.createElement("br"));
 				game_text.append(newChunk);
+				bindGametext();
 			}
 			bindGametext();
 			hide([$('#curtain')]);
 		} else if(msg.cmd == "removechunk") {
 			hideMessage();
-			let index = msg.data;
-			unbindGametext();
-			game_text.children(`#n${index}`).remove()  // Remove the chunk
-			bindGametext();
+			var index = msg.data;
+			var element = game_text.children('#n' + index);
+			if(element.length) {
+				unbindGametext();
+				if((element[0].nextSibling === null || element[0].nextSibling.nodeType !== 1 || element[0].nextSibling.tagName !== "CHUNK") && element[0].previousSibling !== null && element[0].previousSibling.tagName === "CHUNK") {
+					element[0].previousSibling.appendChild(document.createElement("br"));
+				}
+				element.remove();  // Remove the chunk
+				bindGametext();
+			}
 			hide([$('#curtain')]);
 		} else if(msg.cmd == "setgamestate") {
 			// Enable or Disable buttons

--- a/templates/index.html
+++ b/templates/index.html
@@ -6,7 +6,7 @@
 	<meta name="viewport" content="width=device-width, initial-scale=1">
 	<script src="static/jquery-3.6.0.min.js"></script>
 	<script src="static/socket.io.min.js"></script>
-	<script src="static/application.js?ver=1.16.2i"></script>
+	<script src="static/application.js?ver=1.16.2j"></script>
 	<script src="static/bootstrap.min.js"></script>
 	<script src="static/bootstrap-toggle.min.js"></script>
 	<script src="static/rangy-core.min.js"></script>

--- a/templates/index.html
+++ b/templates/index.html
@@ -6,7 +6,7 @@
 	<meta name="viewport" content="width=device-width, initial-scale=1">
 	<script src="static/jquery-3.6.0.min.js"></script>
 	<script src="static/socket.io.min.js"></script>
-	<script src="static/application.js?ver=1.16.2g"></script>
+	<script src="static/application.js?ver=1.16.2h"></script>
 	<script src="static/bootstrap.min.js"></script>
 	<script src="static/bootstrap-toggle.min.js"></script>
 	<script src="static/rangy-core.min.js"></script>

--- a/templates/index.html
+++ b/templates/index.html
@@ -6,7 +6,7 @@
 	<meta name="viewport" content="width=device-width, initial-scale=1">
 	<script src="static/jquery-3.6.0.min.js"></script>
 	<script src="static/socket.io.min.js"></script>
-	<script src="static/application.js?ver=1.16.2e"></script>
+	<script src="static/application.js?ver=1.16.2f"></script>
 	<script src="static/bootstrap.min.js"></script>
 	<script src="static/bootstrap-toggle.min.js"></script>
 	<script src="static/rangy-core.min.js"></script>

--- a/templates/index.html
+++ b/templates/index.html
@@ -6,7 +6,7 @@
 	<meta name="viewport" content="width=device-width, initial-scale=1">
 	<script src="static/jquery-3.6.0.min.js"></script>
 	<script src="static/socket.io.min.js"></script>
-	<script src="static/application.js?ver=1.16.2h"></script>
+	<script src="static/application.js?ver=1.16.2i"></script>
 	<script src="static/bootstrap.min.js"></script>
 	<script src="static/bootstrap-toggle.min.js"></script>
 	<script src="static/rangy-core.min.js"></script>

--- a/templates/index.html
+++ b/templates/index.html
@@ -6,7 +6,7 @@
 	<meta name="viewport" content="width=device-width, initial-scale=1">
 	<script src="static/jquery-3.6.0.min.js"></script>
 	<script src="static/socket.io.min.js"></script>
-	<script src="static/application.js?ver=1.16.2f"></script>
+	<script src="static/application.js?ver=1.16.2g"></script>
 	<script src="static/bootstrap.min.js"></script>
 	<script src="static/bootstrap-toggle.min.js"></script>
 	<script src="static/rangy-core.min.js"></script>


### PR DESCRIPTION
The behaviour varied between browsers but it was universally undesirable in some way outside of Firefox on desktop/Android.

This patch is tested in Chrome and Firefox in Windows 10 and Android 11, Firefox in Ubuntu 16.04, and Safari in macOS Big Sur and iOS 14 (iPhone and iPad).

On a side note it seems like the newest desktop Firefox version somehow broke the ability to delete text from multiple chunks at once by selecting multiple chunks and then pressing backspace. I'll look into that.