### PR TITLE
Create settings directory if it doesn't exist when using InferKit/OAI

### DIFF
--- a/aiserver.py
+++ b/aiserver.py
@@ -276,6 +276,7 @@ if(vars.model == "InferKit"):
         print("{0}Please enter your InferKit API key:{1}\n".format(colors.CYAN, colors.END))
         vars.apikey = input("Key> ")
         # Write API key to file
+        os.makedirs('settings', exist_ok=True)
         file = open("settings/" + getmodelname() + ".settings", "w")
         try:
             js = {"apikey": vars.apikey}
@@ -310,6 +311,7 @@ if(vars.model == "OAI"):
         print("{0}Please enter your OpenAI API key:{1}\n".format(colors.CYAN, colors.END))
         vars.oaiapikey = input("Key> ")
         # Write API key to file
+        os.makedirs('settings', exist_ok=True)
         file = open("settings/" + getmodelname() + ".settings", "w")
         try:
             js = {"oaiapikey": vars.oaiapikey}


### PR DESCRIPTION
The InferKit and OpenAI options didn't create a settings folder if it didn't already exist. People who decide to use InferKit or OpenAI API without first using one of the other options and having their settings saved at least once would have an error thrown since InferKit and OpenAI modes would try to save a file into the nonexistent settings folder.