### PR TITLE
Re-enable the editor mutation observer

### DIFF
--- a/static/application.js
+++ b/static/application.js
@@ -1628,6 +1628,21 @@ function highlightEditingChunks() {
 	}
 }
 
+// This gets run every time the text in a chunk is edited
+// or a chunk is deleted
+function chunkOnDOMMutate(mutations, observer) {
+	if(!gametext_bound || !allowedit) {
+		return;
+	}
+	var nodes = [];
+	for(var i = 0; i < mutations.length; i++) {
+		var mutation = mutations[i];
+		nodes = nodes.concat(Array.from(mutation.addedNodes), Array.from(mutation.removedNodes));
+		nodes.push(mutation.target);
+	}
+	applyChunkDeltas(nodes);
+}
+
 // This gets run every time you try to paste text into the editor
 function chunkOnPaste(event) {
 	// Register the chunk we're pasting in as having been modified
@@ -1705,10 +1720,12 @@ function chunkOnFocusOut(event) {
 }
 
 function bindGametext() {
+	mutation_observer.observe(game_text[0], {characterData: true, childList: true, subtree: true});
 	gametext_bound = true;
 }
 
 function unbindGametext() {
+	mutation_observer.disconnect();
 	gametext_bound = false;
 }
 
@@ -2280,6 +2297,7 @@ $(document).ready(function(){
 	).on('focusout',
 		chunkOnFocusOut
 	);
+	mutation_observer = new MutationObserver(chunkOnDOMMutate);
 
 	// This is required for the editor to work correctly in Firefox on desktop
 	// because the gods of HTML and JavaScript say so

--- a/templates/index.html
+++ b/templates/index.html
@@ -17,7 +17,7 @@
 	<script src="static/bootstrap.min.js"></script>
 	<script src="static/bootstrap-toggle.min.js"></script>
 	<script src="static/rangy-core.min.js"></script>
-	<script src="static/application.js?ver=1.17"></script>
+	<script src="static/application.js?ver=1.17a"></script>
 </head>
 <body>
 	<input type="file" id="remote-save-select" accept="application/json" style="display:none">


### PR DESCRIPTION
In pull request https://github.com/KoboldAI/KoboldAI-Client/pull/82, the mutation observer used by the editor was replaced with a beforeinput event. It turns out there are a small number of actions that cannot be captured by beforeinput alone, such as using the delete key to remove text, and (in Firefox) using the backspace key when the cursor is at the beginning of a chunk.

This pull request adds the mutation observer back in so that we can catch the editor actions that beforeinput does not.