### PR TITLE
Fix glaring issue in chat mode

### DIFF
--- a/aiserver.py
+++ b/aiserver.py
@@ -2402,7 +2402,7 @@ def actionsubmit(data, actionmode=0, force_submit=False, force_prompt_gen=False,
         if(vars.chatmode and vars.gamestarted):
             data = re.sub(r'\n+', ' ', data)
             if(len(data)):
-                data = f"\n{vars.chatname} : {data}\n"
+                data = f"\n{vars.chatname}: {data}\n"
         
         # </s> mode
         if(vars.newlinemode == "s"):


### PR DESCRIPTION
Fixing a spacing issue in chat mode. Makes names go from "John :" to "John:", like they're supposed to be. 