### PR TITLE
Update list of versions with broken OPT again

### DIFF
--- a/aiserver.py
+++ b/aiserver.py
@@ -1359,7 +1359,7 @@ if(not vars.use_colab_tpu and vars.model not in ["InferKit", "Colab", "OAI", "Go
 
 
         # Fix a bug in OPTForCausalLM where self.lm_head is the wrong size
-        if(packaging.version.parse("4.19.0.dev0") <= packaging.version.parse(transformers_version) <= packaging.version.parse("4.19.2")):
+        if(packaging.version.parse("4.19.0.dev0") <= packaging.version.parse(transformers_version) < packaging.version.parse("4.20.0")):
             try:
                 from transformers import OPTForCausalLM, OPTModel
             except ImportError:


### PR DESCRIPTION
They released another version of transformers that still doesn't have the OPT patch so I decided it would be safer to just mark all 4.19 transformers versions as needing the OPT patch.