### PR TITLE
Fix saving of sharded HF models on non-Windows operating systems

### DIFF
--- a/aiserver.py
+++ b/aiserver.py
@@ -1743,7 +1743,7 @@ if(not vars.use_colab_tpu and vars.model not in ["InferKit", "Colab", "OAI", "Go
                                     map_data = json.load(f)
                                 filenames = set(map_data["weight_map"].values())
                                 # Save the pytorch_model.bin.index.json of a sharded model
-                                shutil.move(utils.from_pretrained_index_filename, os.path.join("models/{}".format(vars.model.replace('/', '_')), transformers.modeling_utils.WEIGHTS_INDEX_NAME))
+                                shutil.move(os.path.realpath(utils.from_pretrained_index_filename), os.path.join("models/{}".format(vars.model.replace('/', '_')), transformers.modeling_utils.WEIGHTS_INDEX_NAME))
                                 # Then save the pytorch_model-#####-of-#####.bin files
                                 for filename in filenames:
                                     shutil.move(os.path.realpath(huggingface_hub.hf_hub_download(vars.model, filename, revision=vars.revision, cache_dir="cache", local_files_only=True, legacy_cache_layout=legacy)), os.path.join("models/{}".format(vars.model.replace('/', '_')), filename))


### PR DESCRIPTION
This fixes an issue on non-Windows operating systems where when KoboldAI tries to move the model files out of the HF cache, it moves a symlink to the pytorch_model.bin.index.json out of the cache instead of the real pytorch_model.bin.index.json file, so when the cache is deleted, the symlink would be broken.