### PR TITLE
Cap transformers version

### DIFF
--- a/requirements_mtj.txt
+++ b/requirements_mtj.txt
@@ -5,7 +5,7 @@ requests
 dm-haiku == 0.0.5
 jax == 0.2.21
 jaxlib >= 0.1.69, <= 0.3.7
-transformers >= 4.20.1
+transformers == 4.21.3
 huggingface_hub >= 0.10.1
 progressbar2
 git+https://github.com/VE-FORBRYDERNE/mesh-transformer-jax@ck


### PR DESCRIPTION
Since MTJ is low level, we force a fixed transformers version to have more controlled updates when needed. This fixes today's loading errors.