### PR TITLE
Pin transformers version

### DIFF
--- a/environments/huggingface.yml
+++ b/environments/huggingface.yml
@@ -26,7 +26,7 @@ dependencies:
     - flask-cloudflared
     - flask-ngrok
     - lupa==1.10
-    - transformers>=4.20.1
+    - transformers==4.24.0
     - huggingface_hub>=0.10.1
     - accelerate
     - git+https://github.com/VE-FORBRYDERNE/mkultra

--- a/environments/rocm.yml
+++ b/environments/rocm.yml
@@ -26,7 +26,7 @@ dependencies:
     - flask-cloudflared
     - flask-ngrok
     - lupa==1.10
-    - transformers>=4.20.1
+    - ttransformers==4.24.0
     - huggingface_hub>=0.10.1
     - accelerate
     - git+https://github.com/VE-FORBRYDERNE/mkultra

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-transformers>=4.20.1
+transformers==4.24.0
 huggingface_hub>=0.10.1
 Flask
 Flask-SocketIO

--- a/requirements_mtj.txt
+++ b/requirements_mtj.txt
@@ -5,7 +5,7 @@ requests
 dm-haiku == 0.0.5
 jax == 0.2.21
 jaxlib >= 0.1.69, <= 0.3.7
-transformers == 4.21.3
+transformers == 4.24.0
 huggingface_hub >= 0.10.1
 progressbar2
 git+https://github.com/VE-FORBRYDERNE/mesh-transformer-jax@ck


### PR DESCRIPTION
To avoid breaking changes lets force the exact transformers version we code against. This will be automatically picked up by all the automatic updaters.