### PR TITLE
pin dnspython < 2.3.0 for eventlet patching

### DIFF
--- a/environments/huggingface.yml
+++ b/environments/huggingface.yml
@@ -22,6 +22,7 @@ dependencies:
   - loguru
   - termcolor
   - psutil
+  - dnspython < 2.3.0
   - pip:
     - flask-cloudflared
     - flask-ngrok

--- a/environments/rocm.yml
+++ b/environments/rocm.yml
@@ -19,6 +19,7 @@ dependencies:
   - loguru
   - termcolor
   - psutil
+  - dnspython < 2.3.0
   - pip:
     - --extra-index-url https://download.pytorch.org/whl/rocm5.1.1
     - torch==1.12.1+rocm5.1.1


### PR DESCRIPTION
dnspython updated breaking compatibility with eventlet used in aiserver.py, new installations would show the following error when running play.sh

Traceback (most recent call last):
  File "aiserver.py", line 9, in <module>
    import eventlet
  File "/aiart/kobold/KoboldAI-Client/runtime/envs/koboldai/lib/python3.8/site-packages/eventlet/__init__.py", line 17, in <module>
    from eventlet import convenience
  File "/aiart/kobold/KoboldAI-Client/runtime/envs/koboldai/lib/python3.8/site-packages/eventlet/convenience.py", line 7, in <module>
    from eventlet.green import socket
  File "/aiart/kobold/KoboldAI-Client/runtime/envs/koboldai/lib/python3.8/site-packages/eventlet/green/socket.py", line 21, in <module>
    from eventlet.support import greendns
  File "/aiart/kobold/KoboldAI-Client/runtime/envs/koboldai/lib/python3.8/site-packages/eventlet/support/greendns.py", line 66, in <module>
    setattr(dns, pkg, import_patched('dns.' + pkg))
  File "/aiart/kobold/KoboldAI-Client/runtime/envs/koboldai/lib/python3.8/site-packages/eventlet/support/greendns.py", line 61, in import_patched
    return patcher.import_patched(module_name, **modules)
  File "/aiart/kobold/KoboldAI-Client/runtime/envs/koboldai/lib/python3.8/site-packages/eventlet/patcher.py", line 132, in import_patched
    return inject(
  File "/aiart/kobold/KoboldAI-Client/runtime/envs/koboldai/lib/python3.8/site-packages/eventlet/patcher.py", line 109, in inject
    module = __import__(module_name, {}, {}, module_name.split('.')[:-1])
  File "/aiart/kobold/KoboldAI-Client/runtime/envs/koboldai/lib/python3.8/site-packages/dns/zone.py", line 86, in <module>
    class Zone(dns.transaction.TransactionManager):
  File "/aiart/kobold/KoboldAI-Client/runtime/envs/koboldai/lib/python3.8/site-packages/dns/zone.py", line 757, in Zone
    ) -> dns.rdtypes.ANY.SOA.SOA:
AttributeError: module 'dns.rdtypes' has no attribute 'ANY'