### PR TITLE
Update pytorch+rocm to latest Version

### DIFF
--- a/environments/rocm.yml
+++ b/environments/rocm.yml
@@ -21,8 +21,8 @@ dependencies:
   - termcolor
   - psutil
   - pip:
-    - --extra-index-url https://download.pytorch.org/whl/rocm5.1.1
-    - torch==1.12.1+rocm5.1.1
+    - --extra-index-url https://download.pytorch.org/whl/rocm5.2
+    - torch==1.13.0+rocm5.2
     - flask-cloudflared==0.0.10
     - flask-ngrok
     - lupa==1.10

--- a/environments/rocm.yml
+++ b/environments/rocm.yml
@@ -22,7 +22,7 @@ dependencies:
   - psutil
   - pip:
     - --extra-index-url https://download.pytorch.org/whl/rocm5.2
-    - torch==1.13.0+rocm5.2
+    - torch==1.13.1+rocm5.2
     - flask-cloudflared==0.0.10
     - flask-ngrok
     - lupa==1.10


### PR DESCRIPTION
Tested on a Steam Deck with HSA_OVERRIDE_GFX_VERSION=10.3.0 as env in the docker-compose.yml. Successfully loads and runs OPT up to 350m on the gpu, most layers on 1.3B and up to 14 Layers of 2.7B Models.

I did not observe any Breakage with the updated pytorch Version (Tested with Story and OPT, not with Adventure Models) but more widespread Tests might be required.