### PR TITLE
Allow Project File Access with Podman+Selinux

### DIFF
--- a/docker-cuda/docker-compose.yml
+++ b/docker-cuda/docker-compose.yml
@@ -5,6 +5,8 @@ services:
     environment:
       - DISPLAY=${DISPLAY} 
     network_mode: "host"
+    security_opt:
+      - label:disable
     volumes:
       - /tmp/.X11-unix:/tmp/.X11-unix
       - /etc/protocols:/etc/protocols:ro

--- a/docker-rocm/docker-compose.yml
+++ b/docker-rocm/docker-compose.yml
@@ -5,6 +5,8 @@ services:
     environment:
       - DISPLAY=${DISPLAY} 
     network_mode: "host"
+    security_opt:
+      - label:disable
     volumes:
       - /tmp/.X11-unix:/tmp/.X11-unix
       - /etc/protocols:/etc/protocols:ro


### PR DESCRIPTION
With selinux enabled distros containers accessing KoboldAIs main directory as content, as planned here, will likely generally be denied (atleast with podman). Option 1 would be to mark it with the right label - like :z - but that has other Implications for the content directory.

The other fix, if uglier, is to run the container without labels being enforced and thus allow the file access as the same user and with no further sideeffects to the project file labelling.