### PR TITLE
Added --profile argument.

### DIFF
--- a/aiserver.py
+++ b/aiserver.py
@@ -1369,6 +1369,7 @@ def general_startup(override_args=None):
     parser.add_argument("--no_ui", action='store_true', default=False, help="Disables the GUI and Socket.IO server while leaving the API server running.")
     parser.add_argument('-v', '--verbosity', action='count', default=0, help="The default logging level is ERROR or higher. This value increases the amount of logging seen in your screen")
     parser.add_argument('-q', '--quiesce', action='count', default=0, help="The default logging level is ERROR or higher. This value decreases the amount of logging seen in your screen")
+    parser.add_argument("--profile", type=str, help="Choose Firefox profile to automatically open")
 
     #args: argparse.Namespace = None
     if "pytest" in sys.modules and override_args is None:
@@ -1438,6 +1439,9 @@ def general_startup(override_args=None):
 
     if args.cpu:
         vars.use_colab_tpu = False
+	
+    if args.profile:
+        os.environ['BROWSER'] = str(f"firefox.exe -P '{args.profile}' %s")
 
     vars.smandelete = vars.host == args.override_delete
     vars.smanrename = vars.host == args.override_rename


### PR DESCRIPTION
Adds the option to specify which Firefox profile you want KoboldAI to launch. Only works for Firefox and must have Firefox in PATH.