### PR TITLE
Update install_requirements.sh

### DIFF
--- a/install_requirements.sh
+++ b/install_requirements.sh
@@ -1,12 +1,12 @@
 #!/bin/bash
-if [[ $1 = "cuda" ]]; then
+if [[ $1 = "cuda" ]||[ $1 = "CUDA" ]]; then
 wget -qO- https://micromamba.snakepit.net/api/micromamba/linux-64/latest | tar -xvj bin/micromamba
 bin/micromamba create -f environments/huggingface.yml -r runtime -n koboldai -y
 # Weird micromamba bug causes it to fail the first time, running it twice just to be safe, the second time is much faster
 bin/micromamba create -f environments/huggingface.yml -r runtime -n koboldai -y
 exit
 fi
-if [[ $1 = "rocm" ]]; then
+if [[ $1 = "rocm" ]||[ $1 = "ROCM" ]]; then
 wget -qO- https://micromamba.snakepit.net/api/micromamba/linux-64/latest | tar -xvj bin/micromamba
 bin/micromamba create -f environments/rocm.yml -r runtime -n koboldai-rocm -y
 # Weird micromamba bug causes it to fail the first time, running it twice just to be safe, the second time is much faster


### PR DESCRIPTION
Made parameter case insensitive. The help message "Please specify either CUDA or ROCM" introduces ambiguity that the first parameter might be uppercase.