### PR TITLE
Remove deprecated docker command

### DIFF
--- a/docker-cuda.sh
+++ b/docker-cuda.sh
@@ -1,4 +1,4 @@
 cd docker-cuda
 xhost +local:docker
 cp ../environments/huggingface.yml env.yml
-docker-compose run --service-ports koboldai bash -c "cd /content && python3 aiserver.py $*"
+docker compose run --service-ports koboldai bash -c "cd /content && python3 aiserver.py $*"


### PR DESCRIPTION
`docker-compose` seems to be deprecated in favour of `docker compose`. For more information, run `docker compose --help`, or refer to the documentations [here](https://docs.docker.com/compose/).